### PR TITLE
Added a reusable state toggle element

### DIFF
--- a/frontend/src/ToggleRPC.js
+++ b/frontend/src/ToggleRPC.js
@@ -1,0 +1,22 @@
+import React, { Component } from 'react';
+
+
+export default class Toggle extends Component {
+    state = {
+        on: false,
+    };
+
+    toggle = () => {
+        this.setState({
+            on: !this.state.on
+        });
+    };
+
+    render() {
+        const { children } = this.props;
+        return children({
+            on: this.state.on,
+            toggle: this.toggle
+        })
+    }
+}


### PR DESCRIPTION
Toggle lets you create areas in the code that you want to handle states without having to write the useState. It works as a parent element so when used it needs to be either imported or extended.

Example Use: 

Here I use it to create a collapsable area when you press "Show/Hide" button

<Toggle>
    {({on, toggle}) => (
           <div>
                 {on &&
                      <div>
                            <textarea
                                    className="form-control"
                                    value={body}
                                    onChange={e => setCommentBody(e.target.value)}
                             />
                                <button
                                    className="btn btn-primary"
                                    class="btn-primary"
                                    onClick={() => this.handleComment()}>Save Comment
                                </button>
                       </div>
                        }
                        <button
                            className="btn btn-primary"
                            class="btn-primary"
                            onClick={toggle}>Show/Hide
                       </button>
            </div>
       )}
<Toggle/> 